### PR TITLE
Support for optionally configuring phpunit executable

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -41,6 +41,29 @@ class Config
         return $this->config->source;
     }
 
+    public function getPhpunitConfig()
+    {
+        if (!isset($this->config->phpunit)) {
+            throw new JsonConfigException(
+                'Phpunit destination is not included in configuration file'
+            );
+        }
+        if (!isset($this->config->phpunit->phar)) {
+            throw new JsonConfigException(
+                'full path of phpunit executable is not included in configuration file'
+            );
+        }
+
+        return $this->config->phpunit;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPhpunitConfigured() {
+        return isset($this->config->phpunit);
+    }
+
     public function getTimeout()
     {
         if (!isset($this->config->timeout)) {

--- a/tests/Adapter/Phpunit/Process/PhpunitExecutableFinderTest.php
+++ b/tests/Adapter/Phpunit/Process/PhpunitExecutableFinderTest.php
@@ -19,6 +19,6 @@ class PhpunitExecutableFinderTest extends \PHPUnit_Framework_TestCase
     {
         $finder = new PhpunitExecutableFinder();
         $result = $finder->find();
-        $this->assertRegExp('%phpunit(\\.bat|\\.phar)?$%', $result);
+        $this->assertRegExp('%phpunit.*(\\.bat|\\.phar)?$%', $result);
     }
 }


### PR DESCRIPTION
This is my attempt to implement the feature requested by the user domnikl and me in Issue #154.

Behaviour of the application remains unchanged as long as the user doesn't include the location of a phpunit.phar in the configfile. If he does, path and name of the provided executable will be passed to the ExecutableFinder.

``` json
{
    "source": {
        "directories": [
            "src"
        ]
    },
    ...
    "phpunit": {
        "phar": "/absolute/path/to/phpunit-4.8.3.phar"
    }
}
```

If this pull request somehow doesn't measure up to your expectations for a proper PR or you don't want to implement the feature I would be glad to hear from you.
