### PR TITLE
Mutate only methods, no functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,9 @@ Humbug implements a basic suite of Mutators, which essentially tells us when a
 particular PHP token can be mutated, and also apply that mutation to an array
 of tokens.
 
+Note: Source code held within functions (rather than class methods) is not mutated
+at this time.
+
 Binary Arithmetic:
 
 | Original | Mutated | Original | Mutated |

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -108,7 +108,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function iShouldSeeContaining(PyStringNode $string)
     {
-        if (!preg_match('/' . preg_quote((string) $string) . '/', $this->appTester->getDisplay())) {
+        if (!preg_match('/' . preg_quote((string) $string, '/') . '/', $this->appTester->getDisplay())) {
             throw new \RuntimeException(sprintf(
                 'Output did not match expected pattern:%s%s', PHP_EOL, $this->appTester->getDisplay()
             ));

--- a/features/running/developer_sees_mutant_error_result.feature
+++ b/features/running/developer_sees_mutant_error_result.feature
@@ -23,7 +23,7 @@ Feature: Use Humbug
                     $foo = new Foo;
                     $r = $foo->add(2, 1);
                     // emulate error
-                    if ($r !== 3) $foo->bar();
+                    if ($r !== 3) trigger_error("fail", E_USER_ERROR);
                     $this->assertEquals(3, $r);
                 }
             }

--- a/features/running/developer_sees_mutant_error_result.feature
+++ b/features/running/developer_sees_mutant_error_result.feature
@@ -23,7 +23,7 @@ Feature: Use Humbug
                     $foo = new Foo;
                     $r = $foo->add(2, 1);
                     // emulate error
-                    if ($r !== 3) trigger_error("fail", E_USER_ERROR);
+                    if ($r !== 3) require __DIR__ . "/this.does.not.exist.xyz"; 
                     $this->assertEquals(3, $r);
                 }
             }

--- a/features/running/developer_sees_mutant_error_result.feature
+++ b/features/running/developer_sees_mutant_error_result.feature
@@ -24,7 +24,7 @@ Feature: Use Humbug
                     $foo = new Foo;
                     $r = $foo->add(2, 1);
                     // emulate error
-                    if ($r !== 3) require __DIR__ . "/this.does.not.exist.xyz"; 
+                    if ($r !== 3) require __DIR__ . '/this.does.not.exist.xyz'; 
                     $this->assertEquals(3, $r);
                 }
             }

--- a/features/version.feature
+++ b/features/version.feature
@@ -6,12 +6,16 @@ Feature: Developer runs Humbug with --version option
     Scenario: View Humbug version
         Given I am in any directory
         When I run humbug with "--version"
-        Then I should see:
+        Then I should see output containing:
             """
              _  _            _
             | || |_  _ _ __ | |__ _  _ __ _
             | __ | || | '  \| '_ \ || / _` |
             |_||_|\_,_|_|_|_|_.__/\_,_\__, |
                                       |___/ 
-            Humbug version 1.0-dev
+            Humbug
+            """
+        And I should see output containing:
+            """
+            1.0-dev
             """

--- a/src/Mutable.php
+++ b/src/Mutable.php
@@ -146,7 +146,7 @@ class Mutable
             }
 
             //TODO: handle whitespace!
-            if (is_array($token) && $token[0] == T_FUNCTION) {
+            if (is_array($token) && $token[0] == T_FUNCTION && $className !== '???') {
                 if (!isset($tokens[$index+2][1])) {
                     continue; // ignore closure
                 }

--- a/src/Mutable.php
+++ b/src/Mutable.php
@@ -146,7 +146,7 @@ class Mutable
             }
 
             //TODO: handle whitespace!
-            if (is_array($token) && $token[0] == T_FUNCTION && $className !== '???') {
+            if (is_array($token) && $token[0] == T_FUNCTION && '???' !== $className) {
                 if (!isset($tokens[$index+2][1])) {
                     continue; // ignore closure
                 }


### PR DESCRIPTION
According to @MarkRedeman, only methods should be mutated right now and
function support is pending. `$inMethod` was set to `true` for functions
as well, because it didn't check whether it's inside a class.