### PR TITLE
Run Travis builds for all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ matrix:
     - php: 7.0
     - php: hhvm
     - php: hhvm-nightly
-        
-branches:
-  only:
-    - master
 
 cache:
   directories:


### PR DESCRIPTION
This prevents me from testing branches on my fork. With Humbug being an organisation, we can all make PRs from our forks, so no duplicated builds will be created. Anyway, it can be configured in Travis project settings (if not already done in `.travis.yml` as it is now).