### PR TITLE
Unify version displaying format

### DIFF
--- a/features/version.feature
+++ b/features/version.feature
@@ -12,6 +12,6 @@ Feature: Developer runs Humbug with --version option
             | || |_  _ _ __ | |__ _  _ __ _
             | __ | || | '  \| '_ \ || / _` |
             |_||_|\_,_|_|_|_|_.__/\_,_\__, |
-                                      |___/ 
-            Humbug version 1.0-dev
+                                      |___/
+            Humbug 1.0-dev
             """

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -19,7 +19,7 @@ class Application extends BaseApplication
 | || |_  _ _ __ | |__ _  _ __ _
 | __ | || | \'  \| \'_ \ || / _` |
 |_||_|\_,_|_|_|_|_.__/\_,_\__, |
-                          |___/ ';
+                          |___/';
 
     const NAME = 'Humbug';
 
@@ -33,5 +33,24 @@ class Application extends BaseApplication
             return;
         }
         parent::__construct(self::$logo.PHP_EOL.self::NAME, self::VERSION);
+    }
+
+    /**
+     * @todo Remove when upgrading to symfony/console:^3.0
+     * @see https://github.com/humbug/humbug/issues/219
+     *
+     * {@inheritdoc}
+     */
+    public function getLongVersion()
+    {
+        if ('UNKNOWN' !== $this->getName()) {
+            if ('UNKNOWN' !== $this->getVersion()) {
+                return sprintf('%s <info>%s</info>', $this->getName(), $this->getVersion());
+            }
+
+            return $this->getName();
+        }
+
+        return 'Console Tool';
     }
 }


### PR DESCRIPTION
Part of #219, should solve failing builds on PHP 5.5.