### PR TITLE
Make Behat tests up and running

### DIFF
--- a/features/bootstrap/FilesystemContext.php
+++ b/features/bootstrap/FilesystemContext.php
@@ -39,6 +39,8 @@ class FilesystemContext implements Context, SnippetAcceptingContext
         $this->workingDirectory = tempnam(sys_get_temp_dir(), 'humbug-behat');
         $this->filesystem->remove($this->workingDirectory);
         $this->filesystem->mkdir($this->workingDirectory);
+        $this->filesystem->symlink(__DIR__ . '/../../composer.json', $this->workingDirectory . '/composer.json');
+        $this->filesystem->symlink(__DIR__ . '/../../vendor', $this->workingDirectory . '/vendor');
         chdir($this->workingDirectory);
     }
 


### PR DESCRIPTION
Fixes #219.

Dirty hack to make Humbug use `phpunit` downloaded using Composer.