### PR TITLE
Remove PHP command invoking phpunit script 

### DIFF
--- a/src/Adapter/Phpunit/Process/PhpunitExecutableFinder.php
+++ b/src/Adapter/Phpunit/Process/PhpunitExecutableFinder.php
@@ -17,7 +17,6 @@ use Humbug\Config;
 use Humbug\Config\JsonParser;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ExecutableFinder;
-use Symfony\Component\Process\PhpExecutableFinder;
 
 class PhpunitExecutableFinder extends AbstractExecutableFinder
 {
@@ -100,15 +99,10 @@ class PhpunitExecutableFinder extends AbstractExecutableFinder
     protected function makeExecutable($path)
     {
         $path = realpath($path);
-        $phpFinder = new PhpExecutableFinder();
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-            return sprintf('%s %s %s', 'exec', $phpFinder->find(), $path);
-        } else {
-            if (false !== strpos($path, '.bat')) {
-                return $path;
-            }
-            return sprintf('%s %s', $phpFinder->find(), $path);
+            return sprintf('%s %s', 'exec', $path);
         }
+        return $path;
     }
 
     private function setConfig()


### PR DESCRIPTION
Fixes #159 

There's no error with Ubuntu, but there are scenarios where prefixing the phpunit script with `php` or `exec php` create an error if it's not interpreted as a PHP file.

A possible downside, is that the prefixing might have had a reason in the first place, though likely in far fewer cases than this issue, and we should resolve that more specifically if it's reported as an issue.