### PR TITLE
Basic PSR-2 error fixes from running phpcbf

### DIFF
--- a/src/Adapter/Phpunit.php
+++ b/src/Adapter/Phpunit.php
@@ -49,7 +49,7 @@ class Phpunit extends AdapterAbstract
         $mutantFile = null,
         array $testSuites = []
     ) {
-    
+
         $jobopts = [
             'testdir'       => $container->getTestRunDirectory(),
             'basedir'       => $container->getBaseDirectory(),

--- a/src/Adapter/Phpunit.php
+++ b/src/Adapter/Phpunit.php
@@ -47,8 +47,9 @@ class Phpunit extends AdapterAbstract
         $firstRun = false,
         $interceptFile = null,
         $mutantFile = null,
-        array $testSuites = [])
-    {
+        array $testSuites = []
+    ) {
+    
         $jobopts = [
             'testdir'       => $container->getTestRunDirectory(),
             'basedir'       => $container->getBaseDirectory(),

--- a/src/Adapter/Phpunit.php
+++ b/src/Adapter/Phpunit.php
@@ -49,7 +49,6 @@ class Phpunit extends AdapterAbstract
         $mutantFile = null,
         array $testSuites = []
     ) {
-
         $jobopts = [
             'testdir'       => $container->getTestRunDirectory(),
             'basedir'       => $container->getBaseDirectory(),

--- a/src/Command/Configure.php
+++ b/src/Command/Configure.php
@@ -52,8 +52,11 @@ class Configure extends Command
             return 0;
         }
 
-        $excludeDirs = $this->getDirs($input, $output,
-            'Any directories to exclude from within your source directories? :');
+        $excludeDirs = $this->getDirs(
+            $input,
+            $output,
+            'Any directories to exclude from within your source directories? :'
+        );
 
         $timeout = $this->getTimeout($input, $output);
 
@@ -84,10 +87,10 @@ class Configure extends Command
     {
         $this->setName('configure')
             ->addOption(
-               'force',
-               'f',
-               InputOption::VALUE_NONE,
-               'If it already exists, recreate the configuration anyway.'
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'If it already exists, recreate the configuration anyway.'
             )
         ;
     }

--- a/src/Command/Humbug.php
+++ b/src/Command/Humbug.php
@@ -206,62 +206,62 @@ class Humbug extends Command
             ->setName('run')
             ->setDescription('Run Humbug for target tests')
             ->addOption(
-               'adapter',
-               'a',
-               InputOption::VALUE_REQUIRED,
-               'Set name of the test adapter to use.',
+                'adapter',
+                'a',
+                InputOption::VALUE_REQUIRED,
+                'Set name of the test adapter to use.',
                 'phpunit'
             )
             ->addOption(
-               'options',
-               'o',
-               InputOption::VALUE_REQUIRED,
-               'Set command line options string to pass to test adapter. '
+                'options',
+                'o',
+                InputOption::VALUE_REQUIRED,
+                'Set command line options string to pass to test adapter. '
                     . 'Default is dictated dynamically by '.'Humbug'.'.'
             )
             ->addOption(
-               'file',
-               'f',
-               InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-               'Pattern representing file(s) to mutate. Can set more than once.'
+                'file',
+                'f',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Pattern representing file(s) to mutate. Can set more than once.'
             )
             ->addOption(
-               'constraints',
-               'c',
-               InputOption::VALUE_REQUIRED,
-               'Options set on adapter to constrain which tests are run. '
+                'constraints',
+                'c',
+                InputOption::VALUE_REQUIRED,
+                'Options set on adapter to constrain which tests are run. '
                     . 'Applies only to the very first test run.'
             )
             ->addOption(
-               'timeout',
-               't',
-               InputOption::VALUE_REQUIRED,
-               'Sets a timeout applied for each test run to combat infinite loop mutations.',
+                'timeout',
+                't',
+                InputOption::VALUE_REQUIRED,
+                'Sets a timeout applied for each test run to combat infinite loop mutations.',
                 10
             )
             ->addOption(
-               'no-progress-bar',
-               'b',
-               InputOption::VALUE_NONE,
-               'Removes dynamic output like the progress bar and performance data from output.'
+                'no-progress-bar',
+                'b',
+                InputOption::VALUE_NONE,
+                'Removes dynamic output like the progress bar and performance data from output.'
             )
             ->addOption(
-               'incremental',
-               'i',
-               InputOption::VALUE_NONE,
-               'Enable incremental mutation testing by relying on cached results.'
+                'incremental',
+                'i',
+                InputOption::VALUE_NONE,
+                'Enable incremental mutation testing by relying on cached results.'
             )
             ->addOption(
-               'log-json',
-               null,
-               InputOption::VALUE_REQUIRED,
-               'Generate log file in JSON format.'
+                'log-json',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Generate log file in JSON format.'
             )
             ->addOption(
-               'log-text',
-               null,
-               InputOption::VALUE_REQUIRED,
-               'Generate log file in text format.'
+                'log-text',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Generate log file in text format.'
             )
         ;
     }

--- a/src/Command/SelfUpdate.php
+++ b/src/Command/SelfUpdate.php
@@ -283,40 +283,40 @@ class SelfUpdate extends Command
             ->setName('self-update')
             ->setDescription('Update humbug.phar to most recent stable, pre-release or development build.')
             ->addOption(
-               'dev',
-               'd',
-               InputOption::VALUE_NONE,
-               'Update to most recent development build of Humbug.'
+                'dev',
+                'd',
+                InputOption::VALUE_NONE,
+                'Update to most recent development build of Humbug.'
             )
             ->addOption(
-               'non-dev',
-               'N',
-               InputOption::VALUE_NONE,
-               'Update to most recent non-development (alpha/beta/stable) build of Humbug tagged on Github.'
+                'non-dev',
+                'N',
+                InputOption::VALUE_NONE,
+                'Update to most recent non-development (alpha/beta/stable) build of Humbug tagged on Github.'
             )
             ->addOption(
-               'pre',
-               'p',
-               InputOption::VALUE_NONE,
-               'Update to most recent pre-release version of Humbug (alpha/beta/rc) tagged on Github.'
+                'pre',
+                'p',
+                InputOption::VALUE_NONE,
+                'Update to most recent pre-release version of Humbug (alpha/beta/rc) tagged on Github.'
             )
             ->addOption(
-               'stable',
-               's',
-               InputOption::VALUE_NONE,
-               'Update to most recent stable version tagged on Github.'
+                'stable',
+                's',
+                InputOption::VALUE_NONE,
+                'Update to most recent stable version tagged on Github.'
             )
             ->addOption(
-               'rollback',
-               'r',
-               InputOption::VALUE_NONE,
-               'Rollback to previous version of Humbug if available on filesystem.'
+                'rollback',
+                'r',
+                InputOption::VALUE_NONE,
+                'Rollback to previous version of Humbug if available on filesystem.'
             )
             ->addOption(
-               'check',
-               'c',
-               InputOption::VALUE_NONE,
-               'Checks what updates are available across all possible stability tracks.'
+                'check',
+                'c',
+                InputOption::VALUE_NONE,
+                'Checks what updates are available across all possible stability tracks.'
             )
         ;
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -111,7 +111,8 @@ class Container
     {
         if (!is_dir($dir)) {
             throw new InvalidArgumentException(sprintf(
-                'The cache directory does not exist: %s', $dir
+                'The cache directory does not exist: %s',
+                $dir
             ));
         }
         $this->cacheDirectory = $dir;

--- a/src/Mutator/Arithmetic/Addition.php
+++ b/src/Mutator/Arithmetic/Addition.php
@@ -45,7 +45,6 @@ class Addition extends MutatorAbstract
         if (!is_array($t) && $t == '+') {
             $tokenCount = count($tokens);
             for ($i = $index + 1; $i < $tokenCount; $i++) {
-
                 // check for short array syntax
                 if (!is_array($tokens[$i]) && $tokens[$i][0] == '[') {
                     return false;

--- a/src/ProcessRunner.php
+++ b/src/ProcessRunner.php
@@ -32,11 +32,14 @@ class ProcessRunner
     ) {
         $hasFailure = false;
 
-        $process->run(function ($out, $data) use (
-                $process,
-                $testFrameworkAdapter,
-                $onProgressCallback,
-                &$hasFailure
+        $process->run(function (
+            $out,
+            $data
+        ) use (
+            $process,
+            $testFrameworkAdapter,
+            $onProgressCallback,
+            &$hasFailure
         ) {
             if ($out == Process::ERR) {
                 $hasFailure= true;

--- a/src/Renderer/Text.php
+++ b/src/Renderer/Text.php
@@ -175,7 +175,9 @@ class Text
             $this->write(
                 ' |' . $counter . ' ('
                 . str_pad($current, strlen($count), ' ', STR_PAD_LEFT)
-                . '/' . $count . ')' . PHP_EOL, false);
+                . '/' . $count . ')' . PHP_EOL,
+                false
+            );
         }
     }
 
@@ -196,7 +198,9 @@ class Text
             $this->write(
                 ' |' . $counter . ' ('
                 . str_pad($current, strlen($count), ' ', STR_PAD_LEFT)
-                . '/' . $count . ')' . PHP_EOL, false);
+                . '/' . $count . ')' . PHP_EOL,
+                false
+            );
         }
     }
 

--- a/src/TestSuite/Mutant/IncrementalCache.php
+++ b/src/TestSuite/Mutant/IncrementalCache.php
@@ -117,7 +117,8 @@ class IncrementalCache
     {
         if (!$this->hasResultsFor($file)) {
             throw new RuntimeException(sprintf(
-                'There are no incremental cache results for file: %s', $file
+                'There are no incremental cache results for file: %s',
+                $file
             ));
         }
         return $this->cachedResults[$file];

--- a/src/TestSuite/Mutant/Runner.php
+++ b/src/TestSuite/Mutant/Runner.php
@@ -203,7 +203,6 @@ class Runner
         $mutableFile,
         $index
     ) {
-
         static $fileHits = [];
         static $cacheHits = [];
 

--- a/src/TestSuite/Mutant/Runner.php
+++ b/src/TestSuite/Mutant/Runner.php
@@ -203,7 +203,7 @@ class Runner
         $mutableFile,
         $index
     ) {
-    
+
         static $fileHits = [];
         static $cacheHits = [];
 

--- a/src/TestSuite/Mutant/Runner.php
+++ b/src/TestSuite/Mutant/Runner.php
@@ -201,8 +201,9 @@ class Runner
         CoverageData $coverage,
         Collector $collector,
         $mutableFile,
-        $index)
-    {
+        $index
+    ) {
+    
         static $fileHits = [];
         static $cacheHits = [];
 


### PR DESCRIPTION
Adds additional PSR-2 fixes from implementing #240. PHP CodeSniffer is stricter than StyleCI, but usually for fairly inconsequential things. This just cleans those up so using `composer cs-check` doesn't explode.