### PR TITLE
Include phpmnd (PHP Magic Number Detector) as a dev require

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ build
 composer.lock
 docs
 vendor
+vendor-bin/*/vendor
 
 #Other generic stuff that might be
 composer.phar

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,8 @@
     "scripts": {
         "test": "phpunit",
         "cs:check": "phpcs -pn --standard=PSR2 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=*_files*,*XmlConfigurationBuilderTest.php,*IncludeInterceptor.php",
-        "cs:fix": "phpcbf -pn --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=*_files*,*XmlConfigurationBuilderTest.php,*IncludeInterceptor.php"
+        "cs:fix": "phpcbf -pn --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests --ignore=*_files*,*XmlConfigurationBuilderTest.php,*IncludeInterceptor.php",
+        "post-install-cmd": ["@composer bin all install --ansi"],
+        "post-update-cmd": ["@composer bin all update --ansi"]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "behat/behat": "^3.0.15",
         "symfony/filesystem": "^2.6|^3.0",
         "mikey179/vfsStream": "^1.4",
-        "ciaranmcnulty/versionbasedtestskipper": "^0.2.1"
+        "ciaranmcnulty/versionbasedtestskipper": "^0.2.1",
+        "povils/phpmnd": "^1.0.3"
     },
     "autoload": {
         "psr-4": { "Humbug\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/filesystem": "^2.6|^3.0",
         "mikey179/vfsStream": "^1.4",
         "ciaranmcnulty/versionbasedtestskipper": "^0.2.1",
-        "povils/phpmnd": "^1.0.3"
+        "bamarni/composer-bin-plugin": "^1.1"
     },
     "autoload": {
         "psr-4": { "Humbug\\": "src/" }

--- a/vendor-bin/phpmnd/composer.json
+++ b/vendor-bin/phpmnd/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "povils/phpmnd": "^1.0"
+    }
+}


### PR DESCRIPTION
This is a simple tool for tracking numbers which should be defined via constants (i.e. magic numbers). Something not actually covered by Scrutinizer/PHPMD.