### PR TITLE
[WIP] Escape phpunit command line path arguments

### DIFF
--- a/src/Adapter/Phpunit.php
+++ b/src/Adapter/Phpunit.php
@@ -92,7 +92,7 @@ class Phpunit extends AdapterAbstract
                 unset($jobopts['command'][$key]);
             }
         }
-        array_unshift($jobopts['command'], '--configuration=' . $configFile);
+        array_unshift($jobopts['command'], '--configuration=' . escapeshellarg($configFile));
 
         /**
          * Initial command is expected, of course.
@@ -120,8 +120,8 @@ class Phpunit extends AdapterAbstract
             $container->getBootstrap(),
             $interceptFile
         );
-        
-        $process = new Process(implode(' ', $jobopts['command']), $jobopts['testdir'], array_replace($_ENV, $_SERVER));
+
+        $process = new Process(implode(' ', $jobopts['command']), escapeshellarg($jobopts['testdir']), array_replace($_ENV, $_SERVER));
         $process->setTimeout($timeout);
 
         return $process;

--- a/src/Adapter/Phpunit/Process/PhpunitExecutableFinder.php
+++ b/src/Adapter/Phpunit/Process/PhpunitExecutableFinder.php
@@ -102,12 +102,12 @@ class PhpunitExecutableFinder extends AbstractExecutableFinder
         $path = realpath($path);
         $phpFinder = new PhpExecutableFinder();
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-            return sprintf('%s %s %s', 'exec', $phpFinder->find(), $path);
+            return sprintf('%s %s %s', 'exec', escapeshellarg($phpFinder->find()), escapeshellarg($path));
         } else {
             if (false !== strpos($path, '.bat')) {
-                return $path;
+                return escapeshellarg($path);
             }
-            return sprintf('%s %s', $phpFinder->find(), $path);
+            return sprintf('%s %s', escapeshellarg($phpFinder->find()), escapeshellarg($path));
         }
     }
 

--- a/tests/Adapter/PhpunitTest.php
+++ b/tests/Adapter/PhpunitTest.php
@@ -171,7 +171,7 @@ class PhpunitTest extends \PHPUnit_Framework_TestCase
 
         $result = $process->getOutput();
 
-        $this->assertFalse($adapter->ok($result));
+        $this->assertFalse($adapter->ok($result), $result);
     }
 
     public function testAdapterDetectsTestsFailingFromException()


### PR DESCRIPTION
Fix for #199, but 3 tests failing in loading test files at the moment (appears to be fine outside of the test environment...).