### PR TITLE
Add the missing abstract method MutatorAbstract::getMutation()

### DIFF
--- a/src/Mutator/MutatorAbstract.php
+++ b/src/Mutator/MutatorAbstract.php
@@ -15,6 +15,12 @@ use Humbug\Utility\Tokenizer;
 abstract class MutatorAbstract
 {
     /**
+     * @param array $tokens
+     * @param int $index
+     */
+    abstract public static function getMutation(array &$tokens, $index);
+
+    /**
      * Perform a mutation against the given original source code tokens for
      * a mutable element
      *


### PR DESCRIPTION
All classes inheriting from MutatorAbstract already have the _getMutation()_ method but it is not properly declared.