### PR TITLE
[WIP] Method Visitor::visitElement() must expect a DOMElement instead of a DOMNode

### DIFF
--- a/src/Adapter/Phpunit/XmlConfiguration/ObjectVisitor.php
+++ b/src/Adapter/Phpunit/XmlConfiguration/ObjectVisitor.php
@@ -35,7 +35,7 @@ class ObjectVisitor implements Visitor
         $this->arguments = $arguments;
     }
 
-    public function visitElement(\DOMNode $domElement)
+    public function visitElement(\DOMElement $domElement)
     {
         $domElement->setAttribute('class', $this->className);
         $dom = $domElement->ownerDocument;

--- a/src/Adapter/Phpunit/XmlConfiguration/ReplacePathVisitor.php
+++ b/src/Adapter/Phpunit/XmlConfiguration/ReplacePathVisitor.php
@@ -26,7 +26,7 @@ class ReplacePathVisitor implements Visitor
         $this->locator = $locator;
     }
 
-    public function visitElement(\DOMNode $domElement)
+    public function visitElement(\DOMElement $domElement)
     {
         $domElement->nodeValue = $this->locator->locate($domElement->nodeValue);
     }

--- a/src/Adapter/Phpunit/XmlConfiguration/ReplaceWildcardVisitor.php
+++ b/src/Adapter/Phpunit/XmlConfiguration/ReplaceWildcardVisitor.php
@@ -16,7 +16,7 @@ class ReplaceWildcardVisitor implements Visitor
         $this->locator = $locator;
     }
 
-    public function visitElement(\DOMNode $domElement)
+    public function visitElement(\DOMElement $domElement)
     {
         $directories = $this->locator->locateDirectories($domElement->nodeValue);
 

--- a/src/Adapter/Phpunit/XmlConfiguration/Visitor.php
+++ b/src/Adapter/Phpunit/XmlConfiguration/Visitor.php
@@ -4,5 +4,5 @@ namespace Humbug\Adapter\Phpunit\XmlConfiguration;
 
 interface Visitor
 {
-    public function visitElement(\DOMNode $domElement);
+    public function visitElement(\DOMElement $domElement);
 }


### PR DESCRIPTION
In [ReplaceWildcardVisitor](https://github.com/humbug/humbug/blob/06b1c059e432dab8c22c36bc8b6e1ffc7e587c07/src/Adapter/Phpunit/XmlConfiguration/ReplaceWildcardVisitor.php#L29) the property [tagname](http://php.net/manual/fr/class.domelement.php#domelement.props.tagname) belongs to DOMElement and not DOMNode.
Same thing in [ObjectVisitor](https://github.com/humbug/humbug/blob/06b1c059e432dab8c22c36bc8b6e1ffc7e587c07/src/Adapter/Phpunit/XmlConfiguration/ObjectVisitor.php#L40) with the [getAttribute](http://php.net/manual/fr/domelement.getattribute.php) method.