### PR TITLE
Add depth to directories search

### DIFF
--- a/src/Command/Configure.php
+++ b/src/Command/Configure.php
@@ -61,6 +61,8 @@ class Configure extends Command
 
         $jsonLogFile = $this->getJsonLogFile($input, $output);
 
+        $depth = $this->getDepth($input, $output);
+
         if (!$this->isGenerationConfirmed($input, $output)) {
             $output->writeln('<fg=red>Aborted.</fg=red>' .PHP_EOL);
             return 0;
@@ -72,7 +74,8 @@ class Configure extends Command
             $chDir,
             $timeout,
             $textLogFile,
-            $jsonLogFile
+            $jsonLogFile,
+            $depth
         );
 
         $this->saveConfiguration($configuration);
@@ -124,7 +127,8 @@ class Configure extends Command
         $chDir,
         $timeout,
         $textLogFile,
-        $jsonLogFile
+        $jsonLogFile,
+        $depth
     ) {
         $source = new \stdClass();
         $source->directories = $sourcesDirs;
@@ -150,6 +154,9 @@ class Configure extends Command
             $configuration->logs = $logs;
         }
 
+        if ($depth) {
+            $configuration->depth = $depth;
+        }
         return $configuration;
     }
 
@@ -304,6 +311,17 @@ class Configure extends Command
         $textLogQuestion = new Question('Where do you want to store the json log (if you need it)? : ');
         $textLogFile = $this->getQuestionHelper()->ask($input, $output, $textLogQuestion);
         return $textLogFile;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return string
+     */
+    private function getDepth(InputInterface $input, OutputInterface $output)
+    {
+        $depthQuestion = new Question('Depth of traversing directories recursively (if you want to restrict it) : ');
+        return $this->getQuestionHelper()->ask($input, $output, $depthQuestion);
     }
 
     /**

--- a/src/Command/Humbug.php
+++ b/src/Command/Humbug.php
@@ -166,7 +166,7 @@ class Humbug extends Command
                 $finder->exclude($exclude);
             }
         }
-        if(!\is_null($depth)){
+        if (!\is_null($depth)) {
             $finder->depth($depth);
         }
         return $finder;

--- a/src/Command/Humbug.php
+++ b/src/Command/Humbug.php
@@ -143,7 +143,7 @@ class Humbug extends Command
         }
     }
 
-    protected function prepareFinder($directories, $excludes, array $names = null)
+    protected function prepareFinder($directories, $excludes, array $names = null, $depth = null)
     {
         $finder = new Finder;
         $finder->files();
@@ -165,6 +165,9 @@ class Humbug extends Command
             foreach ($excludes as $exclude) {
                 $finder->exclude($exclude);
             }
+        }
+        if(!\is_null($depth)){
+            $finder->depth($depth);
         }
         return $finder;
     }
@@ -194,7 +197,8 @@ class Humbug extends Command
         $finder = $this->prepareFinder(
             isset($source->directories)? $source->directories : null,
             isset($source->excludes)? $source->excludes : null,
-            $input->getOption('file')
+            $input->getOption('file'),
+            $newConfig->getDepth()
         );
 
         $this->mutableIterator = new MutableIterator($this->container, $finder);

--- a/src/Config.php
+++ b/src/Config.php
@@ -75,6 +75,15 @@ class Config
         return $this->getLogs('text');
     }
 
+    public function getDepth()
+    {
+        if (!isset($this->config->depth)) {
+            return null;
+        }
+
+        return $this->config->depth;
+    }
+
     private function getLogs($type)
     {
         if (!isset($this->config->logs->{$type})) {

--- a/tests/Command/ConfigureTest.php
+++ b/tests/Command/ConfigureTest.php
@@ -66,6 +66,7 @@ class ConfigureTest extends \PHPUnit_Framework_TestCase
             "\n" .
             "\n" .
             "\n" .
+            "\n" .
             "Y\n"
         );
 
@@ -107,6 +108,7 @@ JSON;
             "\n" .
             "\n" .
             "\n" .
+            "\n" .
             "Y\n"
         );
 
@@ -142,6 +144,7 @@ JSON;
             "\n" .
             "custom-log.txt\n" .
             "\n" .
+            "\n" .
             "Y\n"
         );
 
@@ -176,6 +179,7 @@ JSON;
             "\n" .
             "\n" .
             "humbuglog.json\n" .
+            "\n" .
             "Y\n"
         );
 
@@ -210,6 +214,7 @@ JSON;
         $this->setUserInput(
             $srcDir1 . "\n" .
             $srcDir2 . "\n" .
+            "\n" .
             "\n" .
             "\n" .
             "\n" .
@@ -260,6 +265,7 @@ JSON;
             "\n" .
             "\n" .
             "\n" .
+            "\n" .
             "Y\n"
         );
 
@@ -298,6 +304,7 @@ JSON;
             "5\n" .
             "\n" .
             "\n" .
+            "\n" .
             "Y\n"
         );
 
@@ -314,6 +321,42 @@ JSON;
     "logs": {
         "text": "humbuglog.txt"
     }
+}
+JSON;
+
+        $this->assertHumbugJsonEqualsJson($expectedJson);
+    }
+
+    public function testShouldCreateConfigurationWithDepth()
+    {
+        mkdir('src');
+        touch('phpunit.xml');
+
+        $this->setUserInput(
+            "src\n" .
+            "\n" .
+            "\n" .
+            "\n" .
+            "\n" .
+            "\n" .
+            "1\n" .
+            "Y\n"
+        );
+
+        $this->executeCommand();
+
+        $expectedJson = <<<JSON
+{
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "timeout": 10,
+    "logs": {
+        "text": "humbuglog.txt"
+    },
+    "depth" : "1"
 }
 JSON;
 
@@ -343,6 +386,7 @@ JSON;
 
         $this->setUserInput(
             $srcDirName . "\n".
+            "\n" .
             "\n" .
             "\n" .
             "\n" .

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -167,6 +167,21 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($config->getLogsText());
     }
 
+    public function testShouldHaveDepth()
+    {
+        $depth = 1;
+        $configData = new \stdClass();
+        $configData->depth = $depth;
+        $config = new Config($configData);
+        $this->assertSame($depth, $config->getDepth());
+    }
+
+    public function testShouldNotHaveDepth()
+    {
+        $config = new Config(new \stdClass());
+        $this->assertNull($config->getDepth());
+    }
+
     public function testShouldNotRiseExceptionWhenLogsJsonDirNotExists()
     {
         $directory = 'path/to/not-a-dir';


### PR DESCRIPTION
I've added the depth option to use it with Symfony/Finder. I want to mutate the files that diff from master (master -> my_branch) and I need this feature because I can have multiple multiple files with same name in the directory tree. Ex:
```
#git diff --name-only origin/master 
src/Data/GetData.php
```
My only diff is src/Data/GetData.php but my directory tree looks like:

src/Data/GetData.php
src/Data/Request/GetData.php
src/Estimate/Infrastructure/Persistence/DAL/GetData.php

In Symfony/Finder I can't add full path to file so I need to limit the depth of searching files in directories to 0 to mutate only src/Data/GetData.php. 
So my config would like like
```
{
    "timeout": 10,
    "source": {
        "directories": [
            "src/Data"
        ]
    },
    "logs": {
        "text": "humbuglog.txt",
        "json": "humbuglog.json"
    }
}
```
and the command :
`humbug --file=GetData.php `
This way I can assure that only src/Data/GetData.php is analyzed
