### PR TITLE
Add files filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Run `git remote -v` to see what you're actually using.
 - [Command Line Options](#command-line-options)
 	- [Overriding The Configured Timeout](#overriding-the-configured-timeout)
 	- [Restricting Files To Mutate](#restricting-files-to-mutate)
+	- [Mutate specific files](#mutate-specific-files)
 	- [Incremental Analysis](#incremental-analysis)
 - [Performance](#performance)
 - [Mutators](#mutators)
@@ -395,6 +396,21 @@ method.
 
 ```sh
 humbug --file=NewClass.php --file=*Driver.php
+```
+
+This in no way restricts the initial Humbug check on the overall test suite which
+is still executed in full to ensure all tests are passing correctly before
+proceeding.
+
+#### Mutate specific files
+
+If you want to mutate only a few specific files, you can pass 
+any number of `--path` options containing full path file names. This option will be passed 
+to a filter `\Closure` that will intersect files found using the config and/or `--file` option
+ with the files provided by you using the `--path` option.
+
+```sh
+humbug --path=src/Data/NewClass.php --path=src/Driver/Driver.php
 ```
 
 This in no way restricts the initial Humbug check on the overall test suite which

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ to a filter `\Closure` that will intersect files found using the config and/or `
 humbug --path=src/Data/NewClass.php --path=src/Driver/Driver.php
 ```
 
-This in no way restricts the initial Humbug check on the overall test suite which
+Note: This in no way restricts the initial Humbug check on the overall test suite which
 is still executed in full to ensure all tests are passing correctly before
 proceeding.
 

--- a/src/Command/Humbug.php
+++ b/src/Command/Humbug.php
@@ -178,7 +178,7 @@ class Humbug extends Command
 
         if (isset($paths)) {
             $finder->filter(function (SplFileInfo $file) use ($paths) {
-                return \in_array($file, $paths);
+                return in_array($file, $paths);
             });
         }
         return $finder;
@@ -245,7 +245,7 @@ class Humbug extends Command
                 'path',
                 'p',
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-                'Full path file(s) to mutate. If present, an intersection between this and config files will be made!'
+                'Full path file(s) to mutate. If present, an intersection between this and config files will be made.'
             )
             ->addOption(
                 'constraints',

--- a/src/Command/Humbug.php
+++ b/src/Command/Humbug.php
@@ -176,7 +176,7 @@ class Humbug extends Command
             }
         }
 
-        if (isset($paths)) {
+        if (!is_null($paths) && count($paths) > 0) {
             $finder->filter(function (SplFileInfo $file) use ($paths) {
                 return in_array($file, $paths);
             });

--- a/src/Command/Humbug.php
+++ b/src/Command/Humbug.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class Humbug extends Command
 {
@@ -151,7 +152,7 @@ class Humbug extends Command
         }
     }
 
-    protected function prepareFinder($directories, $excludes, array $names = null)
+    protected function prepareFinder($directories, $excludes, array $names = null, $paths = null)
     {
         $finder = new Finder;
         $finder->files();
@@ -173,6 +174,12 @@ class Humbug extends Command
             foreach ($excludes as $exclude) {
                 $finder->exclude($exclude);
             }
+        }
+
+        if (isset($paths)) {
+            $finder->filter(function (SplFileInfo $file) use ($paths) {
+                return \in_array($file, $paths);
+            });
         }
         return $finder;
     }
@@ -202,7 +209,8 @@ class Humbug extends Command
         $finder = $this->prepareFinder(
             isset($source->directories)? $source->directories : null,
             isset($source->excludes)? $source->excludes : null,
-            $input->getOption('file')
+            $input->getOption('file'),
+            $input->getOption('path')
         );
 
         $this->mutableIterator = new MutableIterator($this->container, $finder);
@@ -232,6 +240,12 @@ class Humbug extends Command
                 'f',
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Pattern representing file(s) to mutate. Can set more than once.'
+            )
+            ->addOption(
+                'path',
+                'p',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Full path file(s) to mutate. If present, an intersection between this and config files will be made!'
             )
             ->addOption(
                 'constraints',


### PR DESCRIPTION
I've added the option 'path' for full path files to mutate. Files from path with be intersected with the files found by Symfony/Finder using config directory and 'file' option. 
Ex:
Config:
```json
{
    "timeout": 10,
    "source": {
        "directories": [
            "src"
        ],
        "excludes": [
            "vendor",
            "tests"
        ]
    },
    "logs": {
        "json": "humbug/humbuglog.json"
    }
}
```
Command: 
```
humbug --file=Service.php \
--file=GetData.php \
--path=src/Data/Request/GetData.php \
--path=src/Data/Infrastructure/Persistence/DAL/GetData.php \
--path=src/Data/Response/GetData.php
```

Files found by Symfony/Finder:
```
src/Data/GetData.php
src/Data/Request/GetData.php
src/Data/Infrastructure/Persistence/DAL/GetData.php
src/Data/Service.php
src/Service.php
```

Running the command with the config above the mutated files will be:
```
src/Data/Request/GetData.php
src/Data/Infrastructure/Persistence/DAL/GetData.php
```